### PR TITLE
Fix finalize on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:

--- a/gridmet_bmi/bmi_gridmet.py
+++ b/gridmet_bmi/bmi_gridmet.py
@@ -40,7 +40,10 @@ class BmiGridmet(Bmi):
         printing reports.
         """
         self._day = 0
-        self._model.clear_cache()
+        try:
+            self._model.clear_cache()
+        except PermissionError as error:
+            print(error)
 
     def get_component_name(self) -> str:
         """Name of the component.


### PR DESCRIPTION
This PR applies a band-aid to #1 by emitting a message if a file can't be deleted because it's still in use.