### PR TITLE
Use `pre-commit` for linting and formatting code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,5 @@ jobs:
       - name: Install nox
         run: pip install nox
 
-      - name: Lint code
+      - name: Lint and format code
         run: nox -s lint
-
-      - name: Format code
-        run: nox -s format

--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,3 @@ venv.bak/
 
 # mypy
 .mypy_cache/
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,62 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 26.3.1
+    hooks:
+      - id: black
+        name: black
+        description: "Black: The uncompromising Python code formatter"
+        entry: black
+        language: python
+        language_version: python3
+        minimum_pre_commit_version: 2.9.2
+        require_serial: true
+        types_or: [python, pyi]
+      - id: black-jupyter
+        name: black-jupyter
+        description: "Black: The uncompromising Python code formatter (with Jupyter Notebook support)"
+        entry: black
+        language: python
+        minimum_pre_commit_version: 2.9.2
+        require_serial: true
+        types_or: [python, pyi, jupyter]
+        additional_dependencies: [".[jupyter]"]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          # - flake8-bugbear!=24.4.21
+          # - flake8-comprehensions
+          - flake8-simplify
+
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.9.1
+    hooks:
+      - id: nbqa-pyupgrade
+        args: ["--py310-plus"]
+      # - id: nbqa-isort
+      - id: nbqa-flake8
+        args: ["--extend-ignore=E402"]
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 9.0.0a3
+    hooks:
+      - id: isort
+        name: isort (python)
+        # args: [--force-single-line-imports]
+        types: [python]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-builtin-literals
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: forbid-new-submodules
+      - id: mixed-line-ending
+      - id: trailing-whitespace

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include noxfile.py
 include environment.yml
 include examples/*
 recursive-include tests *
+
+exclude .pre-commit-config.yaml

--- a/notebooks/test_bmi_dev.ipynb
+++ b/notebooks/test_bmi_dev.ipynb
@@ -39,6 +39,7 @@
    ],
    "source": [
     "from gridmet_bmi import BmiGridmet\n",
+    "\n",
     "os.getcwd()"
    ]
   },
@@ -67,7 +68,7 @@
    ],
    "source": [
     "x = BmiGridmet()\n",
-    "x.initialize('../examples/gridmet_bmi.yaml')"
+    "x.initialize(\"../examples/gridmet_bmi.yaml\")"
    ]
   },
   {
@@ -119,7 +120,7 @@
    ],
    "source": [
     "print(x.get_input_var_names())\n",
-    "print(x.get_output_var_names())\n"
+    "print(x.get_output_var_names())"
    ]
   },
   {
@@ -146,12 +147,12 @@
     }
    ],
    "source": [
-    "grid_id = x.get_var_grid('daily_maximum_temperature')\n",
+    "grid_id = x.get_var_grid(\"daily_maximum_temperature\")\n",
     "size = x.get_grid_size(grid_id)\n",
     "bmivals = np.empty(size)\n",
     "shape = np.empty(2, dtype=np.int)\n",
     "x.get_grid_shape(grid_id, shape)\n",
-    "x.get_value('daily_maximum_temperature', bmivals)\n",
+    "x.get_value(\"daily_maximum_temperature\", bmivals)\n",
     "origin = np.empty(2, dtype=np.float)\n",
     "delta = np.empty(2, dtype=np.float)\n",
     "x.get_grid_origin(grid_id, origin)\n",
@@ -203,11 +204,11 @@
     }
    ],
    "source": [
-    "hruid = 'nhru_v11' # for GFv11_v2e\n",
-    "uofi_file = '../examples/agg_met_tmmx_20200101_20200107.nc'\n",
+    "hruid = \"nhru_v11\"  # for GFv11_v2e\n",
+    "uofi_file = \"../examples/agg_met_tmmx_20200101_20200107.nc\"\n",
     "ds = xr.open_dataset(uofi_file)\n",
     "print(ds, flush=True)\n",
-    "#Read NHM hru shapefiles into geopandas dataframe\n",
+    "# Read NHM hru shapefiles into geopandas dataframe\n",
     "print(os.getcwd(), flush=True)"
    ]
   },
@@ -270,10 +271,10 @@
     }
    ],
    "source": [
-    "print(f'rawvalues shape {rawvals.shape}')\n",
-    "print(f'bmivalues shape {bmivals.shape}')\n",
+    "print(f\"rawvalues shape {rawvals.shape}\")\n",
+    "print(f\"bmivalues shape {bmivals.shape}\")\n",
     "bmivals_reshape = np.reshape(bmivals, shape)\n",
-    "print(f'bmivalues reshape {bmivals_reshape.shape}')"
+    "print(f\"bmivalues reshape {bmivals_reshape.shape}\")"
    ]
   },
   {
@@ -291,7 +292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lon, lat = np.meshgrid(ds['lon'], ds['lat'])"
+    "lon, lat = np.meshgrid(ds[\"lon\"], ds[\"lat\"])"
    ]
   },
   {
@@ -323,7 +324,7 @@
     }
    ],
    "source": [
-    "plt.contourf(ds['lon'],ds['lat'], bmivals_reshape)"
+    "plt.contourf(ds[\"lon\"], ds[\"lat\"], bmivals_reshape)"
    ]
   },
   {
@@ -332,10 +333,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    " \n",
     "newlat = np.empty(bmivals_reshape.shape[0], dtype=np.float)\n",
-    "newlon = np.empty(bmivals_reshape.shape[1], dtype=np.float)\n",
-    "   "
+    "newlon = np.empty(bmivals_reshape.shape[1], dtype=np.float)"
    ]
   },
   {
@@ -358,11 +357,11 @@
     "print(delta, origin)\n",
     "\n",
     "for index, val in np.ndenumerate(newlat):\n",
-    "    newlat[index[0]] = origin[0] + (index[0]*delta[0])\n",
-    "    \n",
+    "    newlat[index[0]] = origin[0] + (index[0] * delta[0])\n",
+    "\n",
     "for index, val in np.ndenumerate(newlon):\n",
-    "    newlon[index[0]] = origin[1] + (index[0]*delta[1])\n",
-    "    \n",
+    "    newlon[index[0]] = origin[1] + (index[0] * delta[1])\n",
+    "\n",
     "print(newlat.shape, newlon.shape)\n",
     "print(np.min(newlat), np.max(newlat))\n",
     "print(np.min(newlon), np.max(newlon))"
@@ -418,13 +417,14 @@
    "source": [
     "import rasterstats as rstats\n",
     "import rasterio as rio\n",
-    "#collect data to describe geotransform\n",
-    "lonmin = float(ds.attrs['geospatial_lon_min'])\n",
-    "latmax = float(ds.attrs['geospatial_lat_max'])\n",
-    "lonres = float(ds.attrs['geospatial_lon_resolution'])\n",
-    "latres = float(ds.attrs['geospatial_lon_resolution'])\n",
     "\n",
-    "transform = rio.transform.from_origin( lonmin, latmax, lonres, latres)\n",
+    "# collect data to describe geotransform\n",
+    "lonmin = float(ds.attrs[\"geospatial_lon_min\"])\n",
+    "latmax = float(ds.attrs[\"geospatial_lat_max\"])\n",
+    "lonres = float(ds.attrs[\"geospatial_lon_resolution\"])\n",
+    "latres = float(ds.attrs[\"geospatial_lon_resolution\"])\n",
+    "\n",
+    "transform = rio.transform.from_origin(lonmin, latmax, lonres, latres)\n",
     "print(transform)"
    ]
   },
@@ -460,13 +460,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "geodata = rio.open('test.tif', 'w', driver='GTiff',\n",
-    "                  height=len(newlat), width=len(newlon),\n",
-    "                  count=1, dtype=bmivals_reshape.dtype,\n",
-    "                  crs={'init': 'epsg:4326'},\n",
-    "                  transform=transform)\n",
-    "geodata.write(np.flipud(bmivals_reshape)-273.15, 1)\n",
-    "geodata.close()\n"
+    "geodata = rio.open(\n",
+    "    \"test.tif\",\n",
+    "    \"w\",\n",
+    "    driver=\"GTiff\",\n",
+    "    height=len(newlat),\n",
+    "    width=len(newlon),\n",
+    "    count=1,\n",
+    "    dtype=bmivals_reshape.dtype,\n",
+    "    crs={\"init\": \"epsg:4326\"},\n",
+    "    transform=transform,\n",
+    ")\n",
+    "geodata.write(np.flipud(bmivals_reshape) - 273.15, 1)\n",
+    "geodata.close()"
    ]
   },
   {
@@ -484,8 +490,9 @@
    "source": [
     "import geopandas as gpd\n",
     "import pandas as pd\n",
+    "\n",
     "# read hru shapefile\n",
-    "hrudata = gpd.GeoDataFrame.from_file('./GIS/nhru_10U.shp')"
+    "hrudata = gpd.GeoDataFrame.from_file(\"./GIS/nhru_10U.shp\")"
    ]
   },
   {
@@ -503,11 +510,14 @@
     }
    ],
    "source": [
-    "stats = rstats.zonal_stats(hrudata, np.flipud(bmivals_reshape)-273.15,\n",
-    "                          transform=transform.to_gdal(),\n",
-    "                          prefix='tmax_')\n",
+    "stats = rstats.zonal_stats(\n",
+    "    hrudata,\n",
+    "    np.flipud(bmivals_reshape) - 273.15,\n",
+    "    transform=transform.to_gdal(),\n",
+    "    prefix=\"tmax_\",\n",
+    ")\n",
     "statsdf = pd.DataFrame(stats)\n",
-    "zonalhru = hrudata.join(statsdf)\n"
+    "zonalhru = hrudata.join(statsdf)"
    ]
   },
   {
@@ -539,7 +549,7 @@
     }
    ],
    "source": [
-    "zonalhru.plot(column='tmax_mean')"
+    "zonalhru.plot(column=\"tmax_mean\")"
    ]
   },
   {
@@ -549,6 +559,7 @@
    "outputs": [],
    "source": [
     "import gridmetetl\n",
+    "\n",
     "fp = gridmetetl.FpoNHM()"
    ]
   },
@@ -602,12 +613,21 @@
    ],
    "source": [
     "import datetime\n",
+    "\n",
     "startd = datetime.date(year=2020, month=1, day=1)\n",
     "endd = datetime.date(year=2020, month=1, day=2)\n",
-    "fp.initialize(False, '', './GIS/.', \n",
-    "             '.', './GIS/weights.csv', etype='date', days=0,\n",
-    "             fileprefix='gm_', start_date=startd,\n",
-    "             end_date=endd)"
+    "fp.initialize(\n",
+    "    False,\n",
+    "    \"\",\n",
+    "    \"./GIS/.\",\n",
+    "    \".\",\n",
+    "    \"./GIS/weights.csv\",\n",
+    "    etype=\"date\",\n",
+    "    days=0,\n",
+    "    fileprefix=\"gm_\",\n",
+    "    start_date=startd,\n",
+    "    end_date=endd,\n",
+    ")"
    ]
   },
   {
@@ -670,7 +690,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gmdata = xr.open_dataset('gm_climate_2020_09_01.nc')"
+    "gmdata = xr.open_dataset(\"gm_climate_2020_09_01.nc\")"
    ]
   },
   {
@@ -679,7 +699,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gmtmax = gmdata.tmax.sel(time='2020-01-01')"
+    "gmtmax = gmdata.tmax.sel(time=\"2020-01-01\")"
    ]
   },
   {
@@ -688,7 +708,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "zonalhru['gmtmax'] = gmtmax.values"
+    "zonalhru[\"gmtmax\"] = gmtmax.values"
    ]
   },
   {
@@ -720,7 +740,7 @@
     }
    ],
    "source": [
-    "zonalhru.plot(column='tmax_mean',legend=True)"
+    "zonalhru.plot(column=\"tmax_mean\", legend=True)"
    ]
   },
   {
@@ -752,7 +772,7 @@
     }
    ],
    "source": [
-    "zonalhru.plot(column='gmtmax',legend=True)"
+    "zonalhru.plot(column=\"gmtmax\", legend=True)"
    ]
   },
   {
@@ -761,7 +781,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "zonalhru['diff'] = zonalhru.apply(lambda row: row['tmax_mean'] - row['gmtmax'], axis=1)"
+    "zonalhru[\"diff\"] = zonalhru.apply(lambda row: row[\"tmax_mean\"] - row[\"gmtmax\"], axis=1)"
    ]
   },
   {
@@ -793,7 +813,7 @@
     }
    ],
    "source": [
-    "zonalhru.plot(column='diff',legend=True)"
+    "zonalhru.plot(column=\"diff\", legend=True)"
    ]
   },
   {

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,17 +57,9 @@ def test_bmi(session: nox.Session) -> None:
 
 @nox.session
 def lint(session: nox.Session) -> None:
-    """Clean lint."""
-    session.install("flake8")
-    session.run("flake8", *PATHS)
-
-
-@nox.session
-def format(session: nox.Session) -> None:
-    """Make pretty."""
-    session.install("black", "isort")
-    session.run("isort", *PATHS)
-    session.run("black", *PATHS)
+    """Clean lint and assert style."""
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "--all-files")
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+from contextlib import suppress
 from itertools import chain
 from pathlib import Path
 
@@ -122,15 +123,11 @@ def clean(session: nox.Session) -> None:
 
     for p in chain(ROOT.rglob("*.py[co]"), ROOT.rglob("__pycache__")):
         if p.is_dir():
-            try:
+            with suppress(OSError):
                 shutil.rmtree(p)
-            except OSError:
-                pass
         else:
-            try:
+            with suppress(OSError):
                 p.unlink()
-            except OSError:
-                pass
 
 
 @nox.session(python=False)


### PR DESCRIPTION
Instead of calling *flake8*, *black*, and *isort* independently through *nox* sessions, this PR gathers them under a set of *pre-commit* hooks. Updating this CSDMS Data Component to use *pre-commit* also brings it in line with the other Data Components.