### PR TITLE
Remove miniconda from CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.12
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,11 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          miniforge-version: latest
           python-version: 3.12
-          auto-activate-base: false
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,17 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: actions/setup-python@v5
         with:
-          miniforge-version: latest
-          activate-environment: gridmet_bmi
-          environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
-
-      - name: Show conda installation info
-        run: |
-          conda info
-          conda list
 
       - name: Install nox
         run: |


### PR DESCRIPTION
I've replaced the *setup-miniconda* action with *setup-python* in the CI. Since this is a pure Python project, Miniconda isn't necessary. The *setup-python* action should run faster.