### PR TITLE
Run CI on Python 3.14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.12
+          python-version: 3.14
 
       - name: Install nox
         run: pip install nox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.12"]
+        python-version: ["3.14"]
 
     steps:
       - uses: actions/checkout@v5
@@ -37,7 +37,7 @@ jobs:
           nox -s test -- tests/test_gridmet.py
 
       - name: Test BMI
-        if: ${{ matrix.python-version == '3.12' }}
+        if: ${{ matrix.python-version == '3.14' }}
         run: |
           nox -s test-bmi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: CC0-1.0 License",
   "Operating System :: OS Independent",
   "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ keywords = [
 license = {text = "CC0-1.0 License"}
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -33,7 +32,7 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Intended Audience :: Education",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "bmipy",
   "click",


### PR DESCRIPTION
This PR bumps the Python version used in the CI to 3.14. It also sets Python 3.11 as the minimum supported version for the project.