### PR TITLE
Run CI with all supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v5
@@ -34,12 +34,12 @@ jobs:
 
       - name: Run unit tests (gridmet only, not BMI)
         run: |
-          nox -s test -- tests/test_gridmet.py
+          nox -s test -- tests/test_gridmet.py --python ${{ matrix.python-version }}
 
       - name: Test BMI
         if: ${{ matrix.python-version == '3.14' }}
         run: |
-          nox -s test-bmi
+          nox -s test-bmi --python ${{ matrix.python-version }}
 
       - name: Run examples
         working-directory: ${{ github.workspace }}/examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Run examples
         working-directory: ${{ github.workspace }}/examples
+        if: ${{ matrix.python-version == '3.14' }}
         run: |
           pip install -e ..
           python debug.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run unit tests (gridmet only, not BMI)
         run: |
-          nox -s test -- tests/test_gridmet.py --python ${{ matrix.python-version }}
+          nox -s test --python ${{ matrix.python-version }} -- tests/test_gridmet.py
 
       - name: Test BMI
         if: ${{ matrix.python-version == '3.14' }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,12 +13,13 @@ PACKAGE = PROJECT.replace("-", "_")
 HERE = Path(__file__)
 ROOT = HERE.parent
 PATHS = [PACKAGE, "tests", "examples", HERE.name]
+PYTHON_VERSIONS = ["3.11", "3.12", "3.13", "3.14"]
 
 # Default sessions to run when nox is called without arguments
 nox.options.sessions = ["lint", "test"]
 
 
-@nox.session
+@nox.session(python=PYTHON_VERSIONS)
 def test(session: nox.Session) -> None:
     """Run the tests."""
     session.install(".[testing]")
@@ -39,7 +40,7 @@ def test(session: nox.Session) -> None:
         session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
-@nox.session(name="test-bmi")
+@nox.session(name="test-bmi", python=PYTHON_VERSIONS)
 def test_bmi(session: nox.Session) -> None:
     """Test the BMI with bmi-tester."""
     session.install("bmi-tester")


### PR DESCRIPTION
In #5, I disabled all but one Python version in running the CI tests. I restored them here.